### PR TITLE
Fix the FileSystem tab doesn't refresh on crop

### DIFF
--- a/addons/TileCropper/TileCropper.gd
+++ b/addons/TileCropper/TileCropper.gd
@@ -77,6 +77,7 @@ func _crop_iso_tileset():
 	_calculate_iso_transformations()
 	_build_iso_slices()
 	_build_iso_image()
+	EditorInterface.get_resource_filesystem().scan()
 	info.text = "Done! output saved at '" + output_path + "'"
 	await get_tree().create_timer(waiting_time).timeout
 	iso_button.disabled = false


### PR DESCRIPTION
Hi Pablo. Thank you for the amazing tool. It's a lifesaver!

An issue I noticed is that the _out tileset doesn't appear in the editor after pressing the Crop! button. To see the change the editor has to go to make the editor to lose focus and to get back. It needs something like this to refresh the FileSystem.

I've tested it in Godot 4.4 beta 3 .NET